### PR TITLE
[Feat] 공통 API 응답 구조 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ dependencies {
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.0'
 
 	implementation 'org.apache.commons:commons-lang3:3.18.0'
 

--- a/src/main/java/backend/knowhow/domain/test/controller/TestController.java
+++ b/src/main/java/backend/knowhow/domain/test/controller/TestController.java
@@ -1,0 +1,29 @@
+package backend.knowhow.domain.test.controller;
+
+import backend.knowhow.global.common.exception.BaseException;
+import backend.knowhow.global.common.response.ApiResponse;
+import backend.knowhow.global.common.response.ErrorType;
+import backend.knowhow.global.common.response.SuccessType;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/test")
+public class TestController {
+
+    @GetMapping("/success")
+    public ApiResponse<?> testSuccess() {
+        return ApiResponse.success(SuccessType.SUCCESS, "hello");
+    }
+
+    @GetMapping("/error")
+    public ApiResponse<?> testError() {
+        throw new BaseException(ErrorType.BAD_REQUEST);
+    }
+
+    @GetMapping("/member")
+    public ApiResponse<?> testMemberNotFound() {
+        throw new BaseException(ErrorType.MEMBER_NOT_FOUND);
+    }
+}

--- a/src/main/java/backend/knowhow/global/common/exception/BaseException.java
+++ b/src/main/java/backend/knowhow/global/common/exception/BaseException.java
@@ -1,0 +1,21 @@
+package backend.knowhow.global.common.exception;
+
+import backend.knowhow.global.common.response.ErrorType;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class BaseException extends RuntimeException{
+
+    private final ErrorType errorType;
+
+    public BaseException(ErrorType errorType){
+        super(errorType.getMessage());
+        this.errorType = errorType;
+    }
+
+    public HttpStatus getHttpStatus() {
+        return this.errorType.getHttpStatus();
+    }
+
+}

--- a/src/main/java/backend/knowhow/global/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/backend/knowhow/global/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,26 @@
+package backend.knowhow.global.common.exception;
+
+import backend.knowhow.global.common.response.ApiResponse;
+import backend.knowhow.global.common.response.ErrorType;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(BaseException.class)
+    public ResponseEntity<ApiResponse<?>> handleBaseException(BaseException e) {
+        return ResponseEntity
+                .status(e.getHttpStatus())
+                .body(ApiResponse.error(e.getErrorType()));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiResponse<?>> handleException(Exception e) {
+        return ResponseEntity
+                .status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(ApiResponse.error(ErrorType.INTERNAL_SERVER_ERROR));
+    }
+}

--- a/src/main/java/backend/knowhow/global/common/response/ApiResponse.java
+++ b/src/main/java/backend/knowhow/global/common/response/ApiResponse.java
@@ -11,6 +11,15 @@ public record ApiResponse<T>(
         String message,
         @JsonInclude(JsonInclude.Include.NON_NULL) T data
 ) {
+    public static <T> ApiResponse<T> success(T data) {
+        return new ApiResponse<>(
+                SuccessType.SUCCESS.getHttpStatus().value(),
+                SuccessType.SUCCESS.getCode(),
+                SuccessType.SUCCESS.getMessage(),
+                data
+        );
+    }
+
     public static <T> ApiResponse<T> success(SuccessType success, T data) {
         return new ApiResponse<>(
                 success.getHttpStatus().value(),

--- a/src/main/java/backend/knowhow/global/common/response/ApiResponse.java
+++ b/src/main/java/backend/knowhow/global/common/response/ApiResponse.java
@@ -1,0 +1,38 @@
+package backend.knowhow.global.common.response;
+
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+@JsonPropertyOrder({"status", "code", "message", "data"})
+public record ApiResponse<T>(
+        int status,
+        String code,
+        String message,
+        @JsonInclude(JsonInclude.Include.NON_NULL) T data
+) {
+    public static <T> ApiResponse<T> success(SuccessType success, T data) {
+        return new ApiResponse<>(
+                success.getHttpStatus().value(),
+                success.getCode(),
+                success.getMessage(),
+                data);
+    }
+
+    public static ApiResponse<Void> success(SuccessType success) {
+        return new ApiResponse<>(
+                success.getHttpStatus().value(),
+                success.getCode(),
+                success.getMessage(),
+                null);
+    }
+
+    public static ApiResponse<?> error(ErrorType error) {
+        return new ApiResponse<>(
+                error.getHttpStatus().value(),
+                error.getCode(),
+                error.getMessage(),
+                null);
+    }
+
+}

--- a/src/main/java/backend/knowhow/global/common/response/ErrorType.java
+++ b/src/main/java/backend/knowhow/global/common/response/ErrorType.java
@@ -1,0 +1,28 @@
+package backend.knowhow.global.common.response;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorType {
+
+    // Common
+    BAD_REQUEST(HttpStatus.BAD_REQUEST, "COMMON400", "잘못된 요청입니다."),
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED,"COMMON401", "인증이 필요합니다."),
+    FORBIDDEN(HttpStatus.FORBIDDEN,"COMMON403", "접근이 거부되었습니다."),
+    NOT_FOUND(HttpStatus.NOT_FOUND, "COMMON404", "리소스를 찾을 수 없습니다."),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR,"COMMON500", "서버 내부 오류입니다."),
+
+    // Member
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER404", "회원을 찾을 수 없습니다.");
+
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+
+
+}

--- a/src/main/java/backend/knowhow/global/common/response/SuccessType.java
+++ b/src/main/java/backend/knowhow/global/common/response/SuccessType.java
@@ -1,0 +1,20 @@
+package backend.knowhow.global.common.response;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum SuccessType {
+
+    SUCCESS(HttpStatus.OK,"SUCCESS", "요청이 성공적으로 처리되었습니다."),
+    CREATED(HttpStatus.CREATED, "CREATED", "새 리소스가 생성되었습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+
+
+}


### PR DESCRIPTION
<!--
name: PR 템플릿
about: PR 생성 시 이 템플릿을 사용해 주세요.
title: "[Feat]", "[Fix]", ..
-->
## 🚘 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요. 
- [x] 공통 API 응답 포맷 생성
- [x] 성공/에러 코드 정의
- [x] 전역 예외처리 핸들러 구현

## #️⃣ 테스트 내용
> 어떤 테스트를 수행했는지 명시해주세요.  
- [x] Swagger 테스트
<img width="705" height="130" alt="image" src="https://github.com/user-attachments/assets/452fb27e-f7d9-4b0a-a90b-911f38ba08f7" />
<img width="705" height="107" alt="image" src="https://github.com/user-attachments/assets/504af0d8-6ee5-4998-8bab-7c05e3c698a1" />
<img width="707" height="108" alt="image" src="https://github.com/user-attachments/assets/d95ed472-71c5-48f5-800f-1632c292cbe7" />



## 🚧 구현 중 겪은 이슈 및 해결 방법
> 구현 과정에서 발생한 문제나 오류, 그리고 이를 어떻게 해결했는지 간략히 작성해주세요.
- Springdoc 2.6.0에서 GlobalExceptionHandler와 충돌 발생-> 버전 업데이트
- https://github.com/springdoc/springdoc-openapi/issues/3045

## 🔍 참고 사항
> 코드 리뷰 시 참고해야 할 내용이나 추가적으로 공유할 사항이 있다면 작성해주세요.
- 향후 도메인별 ErrorType 확장할 수 있음
- TestController는 예외/응답 테스트용 임시코드 

## 🔗 관련 이슈
- closes #2 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 표준화된 API 응답 포맷 제공 (상태, 코드, 메시지, 선택적 데이터)
  * 성공/오류 타입 정의로 일관된 메시지 및 상태 노출
  * 진단용 테스트 엔드포인트 추가(성공/일반오류/회원 미조회 응답)

* **Bug Fixes**
  * 글로벌 예외 처리 추가로 예외별 HTTP 상태 및 오류 응답 일관화

* **Chores**
  * OpenAPI 도구 버전 업그레이드 (2.6.0 → 2.8.0)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->