### PR TITLE
[Feat] 보호자 계정 연결 API 구현

### DIFF
--- a/src/main/java/backend/knowhow/domain/auth/controller/AuthController.java
+++ b/src/main/java/backend/knowhow/domain/auth/controller/AuthController.java
@@ -45,7 +45,7 @@ public class AuthController {
     @PostMapping("/logout")
     public ApiResponse<Void> logout(@CurrentUser MemberPrincipal member) {
         authService.logout(member.getId());
-        return ApiResponse.success(null);
+        return ApiResponse.success();
     }
 
 

--- a/src/main/java/backend/knowhow/domain/member/controller/MemberController.java
+++ b/src/main/java/backend/knowhow/domain/member/controller/MemberController.java
@@ -33,7 +33,7 @@ public class MemberController {
         Long seniorId = user.getId();
         String code = connectionCodeService.generateCode(seniorId);
 
-        return ApiResponse.success(new ConnectionCodeResponse(code, 300));
+        return ApiResponse.success(new ConnectionCodeResponse(code, connectionCodeService.getExpireSeconds()));
     }
 
     @PostMapping("/link/connect")

--- a/src/main/java/backend/knowhow/domain/member/controller/MemberController.java
+++ b/src/main/java/backend/knowhow/domain/member/controller/MemberController.java
@@ -10,6 +10,7 @@ import backend.knowhow.global.common.response.ApiResponse;
 import backend.knowhow.global.security.CurrentUser;
 import backend.knowhow.global.security.MemberPrincipal;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -28,6 +29,7 @@ public class MemberController {
         return ApiResponse.success(response);
     }
 
+    @PreAuthorize("hasRole('SENIOR')")
     @PostMapping("/link/generate")
     public ApiResponse<ConnectionCodeResponse> generate(@CurrentUser MemberPrincipal user) {
         Long seniorId = user.getId();
@@ -36,6 +38,7 @@ public class MemberController {
         return ApiResponse.success(new ConnectionCodeResponse(code, connectionCodeService.getExpireSeconds()));
     }
 
+    @PreAuthorize("hasRole('GUARDIAN')")
     @PostMapping("/link/connect")
     public ApiResponse<Void> connect(
             @CurrentUser MemberPrincipal guardian,

--- a/src/main/java/backend/knowhow/domain/member/controller/MemberController.java
+++ b/src/main/java/backend/knowhow/domain/member/controller/MemberController.java
@@ -1,8 +1,10 @@
 package backend.knowhow.domain.member.controller;
 
-import backend.knowhow.domain.auth.dto.request.RoleRequest;
-import backend.knowhow.domain.auth.dto.response.AuthResponse;
+import backend.knowhow.domain.member.dto.request.ConnectRequest;
+import backend.knowhow.domain.member.dto.response.ConnectionCodeResponse;
 import backend.knowhow.domain.member.dto.response.MemberInfoResponse;
+import backend.knowhow.domain.member.service.ConnectionCodeService;
+import backend.knowhow.domain.member.service.GuardianLinkService;
 import backend.knowhow.domain.member.service.MemberService;
 import backend.knowhow.global.common.response.ApiResponse;
 import backend.knowhow.global.security.CurrentUser;
@@ -16,6 +18,8 @@ import org.springframework.web.bind.annotation.*;
 public class MemberController {
 
     private final MemberService memberService;
+    private final ConnectionCodeService connectionCodeService;
+    private final GuardianLinkService guardianLinkService;
 
     @GetMapping("/me")
     public ApiResponse<MemberInfoResponse> getMyInfo(@CurrentUser MemberPrincipal user) {
@@ -24,7 +28,24 @@ public class MemberController {
         return ApiResponse.success(response);
     }
 
+    @PostMapping("/link/generate")
+    public ApiResponse<ConnectionCodeResponse> generate(@CurrentUser MemberPrincipal user) {
+        Long seniorId = user.getId();
+        String code = connectionCodeService.generateCode(seniorId);
 
+        return ApiResponse.success(new ConnectionCodeResponse(code, 300));
+    }
+
+    @PostMapping("/link/connect")
+    public ApiResponse<Void> connect(
+            @CurrentUser MemberPrincipal guardian,
+            @RequestBody ConnectRequest request
+    ) {
+        Long seniorId = connectionCodeService.verifyCode(request.code());
+        guardianLinkService.link(guardian.getId(), seniorId);
+        connectionCodeService.deleteCode(request.code());
+
+        return ApiResponse.success();
+    }
 
 }
-

--- a/src/main/java/backend/knowhow/domain/member/domain/GuardianLink.java
+++ b/src/main/java/backend/knowhow/domain/member/domain/GuardianLink.java
@@ -1,13 +1,14 @@
 package backend.knowhow.domain.member.domain;
 
 import jakarta.persistence.*;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 
 @Entity
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(uniqueConstraints = @UniqueConstraint(columnNames = {"guardian_id", "senior_id"}))
 public class GuardianLink {
 
@@ -22,5 +23,10 @@ public class GuardianLink {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "senior_id", nullable = false)
     private Member senior;
+
+    public GuardianLink(Member guardian, Member senior) {
+        this.guardian = guardian;
+        this.senior = senior;
+    }
 
 }

--- a/src/main/java/backend/knowhow/domain/member/domain/Member.java
+++ b/src/main/java/backend/knowhow/domain/member/domain/Member.java
@@ -4,6 +4,7 @@ import backend.knowhow.domain.auth.dto.response.KakaoUserInfo;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Entity
 @Getter
@@ -29,7 +30,11 @@ public class Member {
         this.role = Role.NONE;
     }
 
-    public void setRole(Role role) {
+    // 테스트 계정 생성자
+    public Member(String nickname, Role role) {
+        this.nickname = nickname;
         this.role = role;
     }
+
+
 }

--- a/src/main/java/backend/knowhow/domain/member/domain/Member.java
+++ b/src/main/java/backend/knowhow/domain/member/domain/Member.java
@@ -19,6 +19,7 @@ public class Member {
 
     private String nickname;
 
+    @Setter
     @Enumerated(EnumType.STRING)
     private Role role;
 

--- a/src/main/java/backend/knowhow/domain/member/domain/Role.java
+++ b/src/main/java/backend/knowhow/domain/member/domain/Role.java
@@ -1,7 +1,7 @@
 package backend.knowhow.domain.member.domain;
 
 public enum Role {
-    DRIVER,
+    SENIOR,
     GUARDIAN,
     NONE
 }

--- a/src/main/java/backend/knowhow/domain/member/dto/request/ConnectRequest.java
+++ b/src/main/java/backend/knowhow/domain/member/dto/request/ConnectRequest.java
@@ -1,0 +1,4 @@
+package backend.knowhow.domain.member.dto.request;
+
+public record ConnectRequest(String code) {
+}

--- a/src/main/java/backend/knowhow/domain/member/dto/response/ConnectionCodeResponse.java
+++ b/src/main/java/backend/knowhow/domain/member/dto/response/ConnectionCodeResponse.java
@@ -1,0 +1,3 @@
+package backend.knowhow.domain.member.dto.response;
+
+public record ConnectionCodeResponse(String code, int expiresIn) {}

--- a/src/main/java/backend/knowhow/domain/member/repository/GuardianLinkRepository.java
+++ b/src/main/java/backend/knowhow/domain/member/repository/GuardianLinkRepository.java
@@ -1,15 +1,10 @@
 package backend.knowhow.domain.member.repository;
 
 import backend.knowhow.domain.member.domain.GuardianLink;
+import backend.knowhow.domain.member.domain.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
-
-import java.util.List;
 
 public interface GuardianLinkRepository extends JpaRepository<GuardianLink, Long> {
 
-    boolean existsByGuardianIdAndSeniorId(Long guardianId, Long seniorId);
-
-    List<GuardianLink> findByGuardianId(Long guardianId);
-
-    List<GuardianLink> findBySeniorId(Long seniorId);
+    boolean existsByGuardianAndSenior(Member guardian, Member senior);
 }

--- a/src/main/java/backend/knowhow/domain/member/service/ConnectionCodeService.java
+++ b/src/main/java/backend/knowhow/domain/member/service/ConnectionCodeService.java
@@ -1,0 +1,49 @@
+package backend.knowhow.domain.member.service;
+
+import backend.knowhow.global.common.exception.BaseException;
+import backend.knowhow.global.common.response.ErrorType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+@Service
+@RequiredArgsConstructor
+public class ConnectionCodeService {
+
+    private final StringRedisTemplate redisTemplate;
+    private static final int EXPIRE_SECONDS = 300;
+
+    public String generateCode(Long seniorId) {
+        String code = String.format("%06d", new Random().nextInt(999999));
+
+        String key = "connection_code:" + code;
+
+        // code -> seniorId 저장
+        redisTemplate.opsForValue().set(
+                key,
+                seniorId.toString(),
+                EXPIRE_SECONDS,
+                TimeUnit.SECONDS
+        );
+
+        return code;
+    }
+
+    public Long verifyCode(String code) {
+        String key = "connection_code:" + code;
+        String seniorIdStr = redisTemplate.opsForValue().get(key);
+
+        if (seniorIdStr == null) {
+            throw new BaseException(ErrorType.INVALID_CONNECTION_CODE);
+        }
+        return Long.valueOf(seniorIdStr);
+    }
+
+    public void deleteCode(String code) {
+        String key = "connection_code:" + code;
+        redisTemplate.delete(key);
+    }
+}

--- a/src/main/java/backend/knowhow/domain/member/service/ConnectionCodeService.java
+++ b/src/main/java/backend/knowhow/domain/member/service/ConnectionCodeService.java
@@ -2,11 +2,13 @@ package backend.knowhow.domain.member.service;
 
 import backend.knowhow.global.common.exception.BaseException;
 import backend.knowhow.global.common.response.ErrorType;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 
-import java.util.Random;
+import java.security.SecureRandom;
 import java.util.concurrent.TimeUnit;
 
 @Service
@@ -14,18 +16,26 @@ import java.util.concurrent.TimeUnit;
 public class ConnectionCodeService {
 
     private final StringRedisTemplate redisTemplate;
-    private static final int EXPIRE_SECONDS = 300;
+    private static final SecureRandom RANDOM = new SecureRandom();
+    private static final String PREFIX = "connection_code:";
+    @Getter
+    @Value("${connection.code.expire-seconds}")
+    private int expireSeconds;
+
 
     public String generateCode(Long seniorId) {
-        String code = String.format("%06d", new Random().nextInt(999999));
-
-        String key = "connection_code:" + code;
+        String code;
+        String key;
+        do {
+            code = String.format("%06d", RANDOM.nextInt(1_000_000));
+            key = PREFIX + code;
+        } while (Boolean.TRUE.equals(redisTemplate.hasKey(key)));
 
         // code -> seniorId 저장
         redisTemplate.opsForValue().set(
                 key,
                 seniorId.toString(),
-                EXPIRE_SECONDS,
+                expireSeconds,
                 TimeUnit.SECONDS
         );
 
@@ -33,7 +43,7 @@ public class ConnectionCodeService {
     }
 
     public Long verifyCode(String code) {
-        String key = "connection_code:" + code;
+        String key = PREFIX + code;
         String seniorIdStr = redisTemplate.opsForValue().get(key);
 
         if (seniorIdStr == null) {
@@ -46,4 +56,5 @@ public class ConnectionCodeService {
         String key = "connection_code:" + code;
         redisTemplate.delete(key);
     }
+
 }

--- a/src/main/java/backend/knowhow/domain/member/service/GuardianLinkService.java
+++ b/src/main/java/backend/knowhow/domain/member/service/GuardianLinkService.java
@@ -1,0 +1,34 @@
+package backend.knowhow.domain.member.service;
+
+import backend.knowhow.domain.member.domain.GuardianLink;
+import backend.knowhow.domain.member.domain.Member;
+import backend.knowhow.domain.member.repository.GuardianLinkRepository;
+import backend.knowhow.domain.member.repository.MemberRepository;
+import backend.knowhow.global.common.exception.BaseException;
+import backend.knowhow.global.common.response.ErrorType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class GuardianLinkService {
+
+    private final GuardianLinkRepository guardianLinkRepository;
+    private final MemberRepository memberRepository;
+
+    public void link(Long guardianId, Long seniorId) {
+
+        Member guardian = memberRepository.findById(guardianId)
+                .orElseThrow(() -> new BaseException(ErrorType.MEMBER_NOT_FOUND));
+
+        Member senior = memberRepository.findById(seniorId)
+                .orElseThrow(() -> new BaseException(ErrorType.MEMBER_NOT_FOUND));
+
+        if (guardianLinkRepository.existsByGuardianAndSenior(guardian, senior)) {
+            throw new BaseException(ErrorType.ALREADY_LINKED);
+        }
+        GuardianLink link = new GuardianLink(guardian, senior);
+        guardianLinkRepository.save(link);
+
+    }
+}

--- a/src/main/java/backend/knowhow/domain/test/controller/TestAuthController.java
+++ b/src/main/java/backend/knowhow/domain/test/controller/TestAuthController.java
@@ -1,0 +1,48 @@
+package backend.knowhow.domain.test.controller;
+
+import backend.knowhow.domain.member.domain.Member;
+import backend.knowhow.domain.member.repository.MemberRepository;
+import backend.knowhow.domain.test.dto.TestLoginRequest;
+import backend.knowhow.domain.test.dto.TestMemberRequest;
+import backend.knowhow.domain.test.dto.TestMemberResponse;
+import backend.knowhow.domain.test.dto.TokenResponse;
+import backend.knowhow.global.common.exception.BaseException;
+import backend.knowhow.global.common.response.ApiResponse;
+import backend.knowhow.global.common.response.ErrorType;
+import backend.knowhow.global.config.JwtUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/auth/test")
+@RequiredArgsConstructor
+public class TestAuthController {
+
+    private final MemberRepository memberRepository;
+    private final JwtUtil jwtUtil;
+
+    @PostMapping("/create")
+    public ApiResponse<TestMemberResponse> createTestMember(
+            @RequestBody TestMemberRequest request
+    ) {
+        Member member = new Member(request.nickname(), request.role());
+        memberRepository.save(member);
+
+        return ApiResponse.success(new TestMemberResponse(member.getId()));
+    }
+
+    @PostMapping("/login")
+    public ApiResponse<TokenResponse> testLogin(
+            @RequestBody TestLoginRequest request
+    ) {
+        Member member = memberRepository.findById(request.memberId())
+                .orElseThrow(() -> new BaseException(ErrorType.MEMBER_NOT_FOUND));
+
+        String token = jwtUtil.createAccessToken(member.getId(), member.getRole());
+
+        return ApiResponse.success(new TokenResponse(token));
+    }
+}

--- a/src/main/java/backend/knowhow/domain/test/dto/TestLoginRequest.java
+++ b/src/main/java/backend/knowhow/domain/test/dto/TestLoginRequest.java
@@ -1,0 +1,5 @@
+package backend.knowhow.domain.test.dto;
+
+public record TestLoginRequest(
+        Long memberId
+) {}

--- a/src/main/java/backend/knowhow/domain/test/dto/TestMemberRequest.java
+++ b/src/main/java/backend/knowhow/domain/test/dto/TestMemberRequest.java
@@ -1,0 +1,9 @@
+package backend.knowhow.domain.test.dto;
+
+import backend.knowhow.domain.member.domain.Role;
+
+public record TestMemberRequest(
+        Long memberId,
+        String nickname,
+        Role role
+) {}

--- a/src/main/java/backend/knowhow/domain/test/dto/TestMemberResponse.java
+++ b/src/main/java/backend/knowhow/domain/test/dto/TestMemberResponse.java
@@ -1,0 +1,4 @@
+package backend.knowhow.domain.test.dto;
+
+public record TestMemberResponse(Long memberId) {
+}

--- a/src/main/java/backend/knowhow/domain/test/dto/TokenResponse.java
+++ b/src/main/java/backend/knowhow/domain/test/dto/TokenResponse.java
@@ -1,0 +1,3 @@
+package backend.knowhow.domain.test.dto;
+
+public record TokenResponse(String accessToken) {}

--- a/src/main/java/backend/knowhow/global/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/backend/knowhow/global/common/exception/GlobalExceptionHandler.java
@@ -4,8 +4,11 @@ import backend.knowhow.global.common.response.ApiResponse;
 import backend.knowhow.global.common.response.ErrorType;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.authorization.AuthorizationDeniedException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
@@ -15,6 +18,11 @@ public class GlobalExceptionHandler {
         return ResponseEntity
                 .status(e.getHttpStatus())
                 .body(ApiResponse.error(e.getErrorType()));
+    }
+
+    @ExceptionHandler({AccessDeniedException.class, AuthorizationDeniedException.class})
+    public void handleSecurityExceptions(RuntimeException e) {
+        throw e;
     }
 
     @ExceptionHandler(Exception.class)

--- a/src/main/java/backend/knowhow/global/common/response/ApiResponse.java
+++ b/src/main/java/backend/knowhow/global/common/response/ApiResponse.java
@@ -20,6 +20,15 @@ public record ApiResponse<T>(
         );
     }
 
+    public static <T> ApiResponse<T> success() {
+        return new ApiResponse<>(
+                SuccessType.SUCCESS.getHttpStatus().value(),
+                SuccessType.SUCCESS.getCode(),
+                SuccessType.SUCCESS.getMessage(),
+                null
+        );
+    }
+
     public static <T> ApiResponse<T> success(SuccessType success, T data) {
         return new ApiResponse<>(
                 success.getHttpStatus().value(),
@@ -35,6 +44,8 @@ public record ApiResponse<T>(
                 success.getMessage(),
                 null);
     }
+
+
 
     public static ApiResponse<?> error(ErrorType error) {
         return new ApiResponse<>(

--- a/src/main/java/backend/knowhow/global/common/response/ErrorType.java
+++ b/src/main/java/backend/knowhow/global/common/response/ErrorType.java
@@ -23,8 +23,8 @@ public enum ErrorType {
     EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH-402", "만료된 토큰입니다."),
     REFRESH_TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "AUTH-403", "Refresh Token을 찾을 수 없습니다."),
     INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH-404", "Refresh Token이 유효하지 않습니다."),
-    TOKEN_REQUIRED(HttpStatus.UNAUTHORIZED, "AUTH-400", "인증이 필요합니다. Authorization 헤더가 비어있습니다."),
-    ACCESS_DENIED(HttpStatus.FORBIDDEN, "AUTH-403", "접근 권한이 없습니다."),
+    TOKEN_REQUIRED(HttpStatus.UNAUTHORIZED, "AUTH-405", "인증이 필요합니다. Authorization 헤더가 비어있습니다."),
+    ACCESS_DENIED(HttpStatus.FORBIDDEN, "AUTH-406", "접근 권한이 없습니다."),
 
     // OAuth
     KAKAO_TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "KAKAO-401", "카카오 AccessToken이 유효하지 않습니다."),
@@ -34,9 +34,6 @@ public enum ErrorType {
     INVALID_CONNECTION_CODE(HttpStatus.BAD_REQUEST, "CONNECT-400", "연동코드가 올바르지 않거나 만료되었습니다."),
     ALREADY_LINKED(HttpStatus.CONFLICT, "CONNECT-401", "이미 연결된 관계입니다."),
     CONNECTION_CODE_NOT_FOUND(HttpStatus.NOT_FOUND, "CONNECT-402", "연동코드를 찾을 수 없습니다.");
-
-
-
 
 
     private final HttpStatus httpStatus;

--- a/src/main/java/backend/knowhow/global/common/response/ErrorType.java
+++ b/src/main/java/backend/knowhow/global/common/response/ErrorType.java
@@ -23,10 +23,19 @@ public enum ErrorType {
     EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH-402", "만료된 토큰입니다."),
     REFRESH_TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "AUTH-403", "Refresh Token을 찾을 수 없습니다."),
     INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH-404", "Refresh Token이 유효하지 않습니다."),
+    TOKEN_REQUIRED(HttpStatus.UNAUTHORIZED, "AUTH-400", "인증이 필요합니다. Authorization 헤더가 비어있습니다."),
+    ACCESS_DENIED(HttpStatus.FORBIDDEN, "AUTH-403", "접근 권한이 없습니다."),
 
     // OAuth
     KAKAO_TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "KAKAO-401", "카카오 AccessToken이 유효하지 않습니다."),
-    EXTERNAL_API_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "EXTERNAL-500", "외부 API 호출 중 오류가 발생했습니다.");
+    EXTERNAL_API_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "EXTERNAL-500", "외부 API 호출 중 오류가 발생했습니다."),
+
+    // Connection
+    INVALID_CONNECTION_CODE(HttpStatus.BAD_REQUEST, "CONNECT-400", "연동코드가 올바르지 않거나 만료되었습니다."),
+    ALREADY_LINKED(HttpStatus.CONFLICT, "CONNECT-401", "이미 연결된 관계입니다."),
+    CONNECTION_CODE_NOT_FOUND(HttpStatus.NOT_FOUND, "CONNECT-402", "연동코드를 찾을 수 없습니다.");
+
+
 
 
 

--- a/src/main/java/backend/knowhow/global/config/SecurityConfig.java
+++ b/src/main/java/backend/knowhow/global/config/SecurityConfig.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -16,6 +17,7 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
+@EnableMethodSecurity(prePostEnabled = true)
 @EnableWebSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
@@ -42,15 +44,25 @@ public class SecurityConfig {
                 )
                 .authorizeHttpRequests(req -> {
                     if (activeProfile.equals("dev") || activeProfile.equals("local")) {
-                        req.requestMatchers("/test/**", "/h2-console/**").permitAll();
+                        req.requestMatchers( "/h2-console/**").permitAll();
                     }
-                    req.requestMatchers("/auth/**", "/swagger-ui/**","/v3/api-docs/**","/api-docs/**")
-                            .permitAll()
-                            .anyRequest().authenticated();
+                    req.requestMatchers(
+                            "/auth/kakao",
+                            "/auth/refresh",
+                            "/auth/test/*"
+                    ).permitAll();
+                    req.requestMatchers(
+                            "/swagger-ui/**",
+                            "/v3/api-docs/**",
+                            "/api-docs/**"
+                    ).permitAll();
+                    req.requestMatchers("/auth/**").authenticated();
+                    req.anyRequest().authenticated();
                 })
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 
         http.headers(headers -> headers.frameOptions(HeadersConfigurer.FrameOptionsConfig::disable));
+        System.out.println("SecurityConfig loaded!!!");
 
         return http.build();
     }

--- a/src/main/java/backend/knowhow/global/config/SecurityConfig.java
+++ b/src/main/java/backend/knowhow/global/config/SecurityConfig.java
@@ -1,5 +1,7 @@
 package backend.knowhow.global.config;
 
+import backend.knowhow.global.security.CustomAccessDeniedHandler;
+import backend.knowhow.global.security.CustomAuthenticationEntryPoint;
 import backend.knowhow.global.security.JwtAuthenticationFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -22,6 +24,8 @@ public class SecurityConfig {
     private String activeProfile;
 
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
+    private final CustomAccessDeniedHandler customAccessDeniedHandler;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -32,6 +36,10 @@ public class SecurityConfig {
                 .httpBasic(AbstractHttpConfigurer::disable)
                 .sessionManagement(sm ->
                         sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .exceptionHandling(ex -> ex
+                        .authenticationEntryPoint(customAuthenticationEntryPoint)
+                        .accessDeniedHandler(customAccessDeniedHandler)
+                )
                 .authorizeHttpRequests(req -> {
                     if (activeProfile.equals("dev") || activeProfile.equals("local")) {
                         req.requestMatchers("/test/**", "/h2-console/**").permitAll();

--- a/src/main/java/backend/knowhow/global/security/CustomAccessDeniedHandler.java
+++ b/src/main/java/backend/knowhow/global/security/CustomAccessDeniedHandler.java
@@ -1,0 +1,35 @@
+package backend.knowhow.global.security;
+
+import backend.knowhow.global.common.response.ErrorType;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+
+    @Override
+    public void handle(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            AccessDeniedException accessDeniedException) throws IOException {
+
+        ErrorType errorType = ErrorType.ACCESS_DENIED;
+
+        response.setStatus(errorType.getHttpStatus().value());
+        response.setContentType("application/json; charset=UTF-8");
+
+        String json = String.format(
+                "{ \"status\": %d, \"code\": \"%s\", \"message\": \"%s\", \"data\": null }",
+                errorType.getHttpStatus().value(),
+                errorType.getCode(),
+                errorType.getMessage()
+        );
+
+        response.getWriter().write(json);
+    }
+}

--- a/src/main/java/backend/knowhow/global/security/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/backend/knowhow/global/security/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,35 @@
+package backend.knowhow.global.security;
+
+import backend.knowhow.global.common.response.ErrorType;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    @Override
+    public void commence(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            AuthenticationException authException) throws IOException {
+
+        ErrorType errorType = ErrorType.TOKEN_REQUIRED;
+
+        response.setStatus(errorType.getHttpStatus().value());
+        response.setContentType("application/json; charset=UTF-8");
+
+        String json = String.format(
+                "{ \"status\": %d, \"code\": \"%s\", \"message\": \"%s\", \"data\": null }",
+                errorType.getHttpStatus().value(),
+                errorType.getCode(),
+                errorType.getMessage()
+        );
+
+        response.getWriter().write(json);
+    }
+}


### PR DESCRIPTION
<!--
name: PR 템플릿
about: PR 생성 시 이 템플릿을 사용해 주세요.
title: "[Feat]", "[Fix]", ..
-->
## 🚘 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요. 
- [x] Guardian–Senior 연결 API 구현
- [x] `ApiResponse` 디폴트 `success()` 메서드 추가
- [x] 개발용 `TestAuthController` 및 테스트 DTO 추가
- [x] `AuthenticationEntryPoint`, `AccessDeniedHandler` 등록


## 🔗 관련 이슈
- closes #8 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 보호자-시니어 연결: 연결 코드 생성, 코드 검증 및 연결 처리 기능 추가
  * 테스트 인증 엔드포인트: 테스트용 회원 생성 및 로그인 토큰 발급 지원

* **개선사항**
  * 보안 오류 처리 강화: 인증 필요 및 접근 거부 시 표준화된 JSON 오류 응답 적용
  * 연결 코드 만료 정보 제공 및 만료 처리 추가

* **Chores**
  * 로그아웃 응답 형식 표준화 (빈 성공 응답)

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->