### PR TITLE
[Chore] Docker 기반 로컬 MySQL 환경으로 개발 서버 구성 변경

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ out/
 src/main/resources/application.yml
 src/main/resources/application-dev.yml
 src/main/resources/application-local.yml
+.env

--- a/build.gradle
+++ b/build.gradle
@@ -52,6 +52,9 @@ dependencies {
 
 
 }
+jar {
+	enabled = false
+}
 
 tasks.named('test') {
 	useJUnitPlatform()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,5 @@
+version: '3.8'
+
 services:
   backend:
     image: jaehyuun/careride
@@ -6,10 +8,18 @@ services:
       - "8080:8080"
     restart: always
     depends_on:
-      - redis
+      redis:
+        condition: service_started
+      mysql:
+        condition: service_healthy
     environment:
-      - SPRING_PROFILES_ACTIVE=dev
-      - REDIS_HOST=redis
+      SPRING_PROFILES_ACTIVE: dev
+      REDIS_HOST: redis
+      MYSQL_HOST: mysql
+      MYSQL_PORT: 3306
+      MYSQL_DATABASE: careridedb
+      MYSQL_USER: root
+      MYSQL_PASSWORD: ${MYSQL_PASSWORD}
 
   redis:
     image: redis:7.2
@@ -17,3 +27,27 @@ services:
     ports:
       - "6379:6379"
     restart: always
+
+  mysql:
+    image: mysql:8.0.33
+    container_name: careridemysql
+    ports:
+      - "3306:3306"
+    restart: always
+    environment:
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
+      MYSQL_DATABASE: careridedb
+    command:
+      - --character-set-server=utf8mb4
+      - --collation-server=utf8mb4_unicode_ci
+      - --innodb-buffer-pool-size=128M
+    volumes:
+      - test-mysql-data:/var/lib/mysql
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-p${MYSQL_ROOT_PASSWORD}"]
+      interval: 10s
+      retries: 10
+      timeout: 5s
+
+volumes:
+  test-mysql-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       MYSQL_PORT: 3306
       MYSQL_DATABASE: careridedb
       MYSQL_USER: root
-      MYSQL_PASSWORD: ${MYSQL_PASSWORD}
+      MYSQL_PASSWORD: ${MYSQL_ROOT_PASSWORD}
 
   redis:
     image: redis:7.2
@@ -44,7 +44,7 @@ services:
     volumes:
       - test-mysql-data:/var/lib/mysql
     healthcheck:
-      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-p${MYSQL_ROOT_PASSWORD}"]
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
       interval: 10s
       retries: 10
       timeout: 5s


### PR DESCRIPTION
<!--
name: PR 템플릿
about: PR 생성 시 이 템플릿을 사용해 주세요.
title: "[Feat]", "[Fix]", ..
-->
## 🚘 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요. 
- [x] `build.gradle`에서 plain JAR 생성 비활성화
- [x] 개발 배포환경에서 로컬 MySQL(docker) 기반 개발 환경 구성
- [x] `.env` 파일 생성


## 🚧 구현 중 겪은 이슈 및 해결 방법
> 구현 과정에서 발생한 문제나 오류, 그리고 이를 어떻게 해결했는지 간략히 작성해주세요.
- 기존 RDS 비용 문제로 Docker 내부 MySQL로 전환하는 과정에서 
t3.micro 환경에서 MySQL 컨테이너가 높은 메모리를 사용하여 `mysqld` 프로세스가 OOM-Killer에 의해 강제로 종료되는 문제 발생
- 아래 시스템 로그에서 `Out of memory: Killed process 2438 (mysqld)` 메시지 확인
<img width="1118" height="252" alt="스크린샷 2025-11-25 132933" src="https://github.com/user-attachments/assets/4f23abef-f881-40e3-b607-145cfcfeb220" />

- EC2 인스턴스에 2GB swap 공간을 추가하여 메모리 부족에 의해 컨테이너 강제 종료되는 문제 해결





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * 환경변수 파일(.env)을 버전관리에서 제외하도록 설정해 비밀값 노출 방지 강화
  * 빌드 과정에서 JAR 생성 작업을 비활성화해 배포 흐름 최적화
  * 로컬 개발용으로 MySQL 서비스 추가, 포트·볼륨·헬스체크 및 관련 환경변수 구성으로 데이터베이스 통합 지원
  * 컨테이너 의존성 및 환경변수 선언 방식을 명확히 하고 재시작 정책 유지

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->