### PR TITLE
[Feat] 교통사고 다발지역 api 실시간 조회

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,7 +56,9 @@ dependencies {
 	// Apache HttpClient
 	implementation 'org.apache.httpcomponents.client5:httpclient5:5.4.1'
 
-
+	// JTS (Geo)
+	implementation 'org.locationtech.jts:jts-core:1.19.0'
+	implementation 'org.locationtech.jts.io:jts-io-common:1.19.0'
 }
 jar {
 	enabled = false

--- a/src/main/java/backend/knowhow/domain/alert/client/KoroadApiClient.java
+++ b/src/main/java/backend/knowhow/domain/alert/client/KoroadApiClient.java
@@ -57,11 +57,8 @@ public class KoroadApiClient {
                 + "&numOfRows=9999"
                 + "&pageNo=1";
 
-        log.info("url : {}", url);
-
         try {
             KoroadBaseResponse res = restTemplate.getForObject(url, KoroadBaseResponse.class);
-            log.info("Aaaa");
             if (res == null) {
                 log.warn("[KoroadApiClient] Null response. url={}", url);
                 return Collections.emptyList();

--- a/src/main/java/backend/knowhow/domain/alert/client/KoroadApiClient.java
+++ b/src/main/java/backend/knowhow/domain/alert/client/KoroadApiClient.java
@@ -1,0 +1,89 @@
+package backend.knowhow.domain.alert.client;
+
+import backend.knowhow.domain.alert.dto.external.KoroadBaseResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class KoroadApiClient {
+
+    private final RestTemplate restTemplate;
+
+    @Value("${koroad.api-key}")
+    private String apiKey;
+
+    @Value("${koroad.base-url}")
+    private String baseUrl;
+
+    private static final int searchYear = 2015;  // 최근 3년 기준 연도
+    private static final String PATH_OLDMAN = "/frequentzoneOldman/getRestFrequentzoneOldman";
+    private static final String PATH_CHILD = "/frequentzoneChild/getRestFrequentzoneChild";
+    private static final String PATH_SCHOOL = "/frequentzoneChildSchool/getRestFrequentzoneChildSchool";
+
+    // API 선택 → path 반환
+    private String resolvePath(String type) {
+        return switch (type.toLowerCase()) {
+            case "oldman" -> PATH_OLDMAN;
+            case "child" -> PATH_CHILD;
+            case "school" -> PATH_SCHOOL;
+            default -> throw new IllegalArgumentException("Unknown Koroad type: " + type);
+        };
+    }
+
+    // Koroad API 호출 공통 함수
+    public List<KoroadBaseResponse.Item> fetchHotspots(
+            String type,   // "oldman", "child", "school"
+            Integer siDo,
+            Integer guGun
+    ) {
+        String path = resolvePath(type);
+
+        String url = baseUrl + path
+                + "?serviceKey=" + apiKey
+                + "&searchYearCd=" + searchYear
+                + "&siDo=" + siDo
+                + "&guGun=" + guGun
+                + "&type=json"
+                + "&numOfRows=9999"
+                + "&pageNo=1";
+
+        log.info("url : {}", url);
+
+        try {
+            KoroadBaseResponse res = restTemplate.getForObject(url, KoroadBaseResponse.class);
+            log.info("Aaaa");
+            if (res == null) {
+                log.warn("[KoroadApiClient] Null response. url={}", url);
+                return Collections.emptyList();
+            }
+
+            if (!"00".equals(res.getResultCode())) {
+                log.warn(
+                        "[KoroadApiClient] API error. url={}, code={}, msg={}",
+                        url, res.getResultCode(), res.getResultMsg()
+                );
+                return Collections.emptyList();
+            }
+
+            List<KoroadBaseResponse.Item> items = res.getItemList();
+            log.info("[KoroadApiClient] success. type={}, siDo={}, guGun={}, itemCount={}",
+                    type, siDo, guGun, items.size());
+
+            return items;
+        }
+        catch (Exception e) {
+            log.error("[KoroadApiClient] fetchHotspots error. type={}, url={}, message={}", type, url, e.getMessage(), e);
+            return Collections.emptyList();
+        }
+    }
+}

--- a/src/main/java/backend/knowhow/domain/alert/controller/KoroadHotspotSyncController.java
+++ b/src/main/java/backend/knowhow/domain/alert/controller/KoroadHotspotSyncController.java
@@ -1,0 +1,77 @@
+package backend.knowhow.domain.alert.controller;
+
+import backend.knowhow.domain.alert.service.KoroadHotspotSyncService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@Slf4j
+@RequestMapping("/koroad")
+public class KoroadHotspotSyncController {
+
+    private final KoroadHotspotSyncService syncService;
+
+    // 서울 시도 코드
+    private static final int SEOUL_SIDO = 11;
+
+    // 서울 전체 구/군 코드 목록 (Koroad 기준)
+    private static final List<Integer> SEOUL_GUGUN_CODES = List.of(
+            110, // 종로구
+            140, // 중구
+            170, // 용산구
+            200, // 성동구
+            215, // 광진구
+            230, // 동대문구
+            260, // 중랑구
+            290, // 성북구
+            305, // 강북구
+            320, // 도봉구
+            350, // 노원구
+            380, // 은평구
+            410, // 서대문구
+            440, // 마포구
+            470, // 양천구
+            500, // 강서구
+            530, // 구로구
+            545, // 금천구
+            560, // 영등포구
+            590, // 동작구
+            620, // 관악구
+            650, // 서초구
+            680, // 강남구
+            710, // 송파구
+            740  // 강동구
+    );
+
+    /**
+     * 서울 전체 Koroad 다발지역 동기화
+     *
+     * 예)
+     *  - 보행노인 사고 다발지역 전체: apiType=oldman&type=OLD_MAN
+     *  - 보행어린이: apiType=child&type=CHILD
+     *  - 어린이보호구역: apiType=school&type=SCHOOL
+     */
+    @PostMapping("/sync/seoul")
+    public String syncSeoul(
+            @RequestParam String apiType,  // KoroadApiClient 에서 사용하는 구분자 ("oldman", "child", "school" 등)
+            @RequestParam String type      // DB KoroadHotspot.type 에 저장할 값 ("OLD_MAN", "CHILD", "SCHOOL" 등)
+    ) {
+
+        log.info("start");
+        int total = 0;
+
+        for (Integer guGun : SEOUL_GUGUN_CODES) {
+            syncService.syncHotspots(apiType, type, SEOUL_SIDO, guGun);
+            log.info("{} finish", guGun);
+            total++;
+        }
+
+        return String.format("Synced Seoul Koroad hotspots for apiType=%s, type=%s, gugunCount=%d",
+                apiType, type, total);
+    }
+}
+

--- a/src/main/java/backend/knowhow/domain/alert/domain/KoroadHotspot.java
+++ b/src/main/java/backend/knowhow/domain/alert/domain/KoroadHotspot.java
@@ -1,0 +1,55 @@
+package backend.knowhow.domain.alert.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "koroad_hotspot")
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class KoroadHotspot {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    /**
+     * koroad 타입
+     * - OLD_MAN : 보행노인
+     * - CHILD   : 보행어린이
+     * - SCHOOL  : 어린이보호구역
+     */
+    @Column(nullable = false, length = 20)
+    private String type;
+
+    @Column(name = "afos_fid", length = 50)
+    private String afosFid;
+
+    @Column(name = "spot_name", length = 200)
+    private String spotName;
+
+    @Column(name = "sido_sgg_name", length = 100)
+    private String sidoSggName;
+
+    // Koroad API 호출 시 사용했던 시/도, 구/군 코드 (검색 범위 관리용)
+    private Integer siDo;
+    private Integer guGun;
+
+    @Column(name = "accident_count")
+    private Integer accidentCount;
+
+    @Column(name = "lat")
+    private Double lat;
+
+    @Column(name = "lon")
+    private Double lon;
+
+    // Koroad에서 내려주는 geom_json 그대로 저장 (GeoJSON 문자열)
+    @Lob
+    @Column(name = "geom_json", columnDefinition = "TEXT")
+    private String geomJson;
+}
+

--- a/src/main/java/backend/knowhow/domain/alert/dto/external/KoroadBaseResponse.java
+++ b/src/main/java/backend/knowhow/domain/alert/dto/external/KoroadBaseResponse.java
@@ -1,0 +1,79 @@
+package backend.knowhow.domain.alert.dto.external;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class KoroadBaseResponse {
+
+    private String resultCode;
+    private String resultMsg;
+
+    private Items items;
+
+    private int totalCount;
+    private int numOfRows;
+    private int pageNo;
+
+    @Getter
+    public static class Items {
+        private List<Item> item;
+    }
+
+    @Getter
+    public static class Item {
+
+        @JsonProperty("afos_fid")
+        private Long afosFid;
+
+        @JsonProperty("afos_id")
+        private String afosId;
+
+        @JsonProperty("bjd_cd")
+        private String bjdCd;
+
+        @JsonProperty("spot_cd")
+        private String spotCd;
+
+        @JsonProperty("sido_sgg_nm")
+        private String sidoSggName;
+
+        @JsonProperty("spot_nm")
+        private String spotName;
+
+        @JsonProperty("occrrnc_cnt")
+        private Integer accidentCount;
+
+        @JsonProperty("caslt_cnt")
+        private Integer casltCnt;
+
+        @JsonProperty("dth_dnv_cnt")
+        private Integer dthDnvCnt;
+
+        @JsonProperty("se_dnv_cnt")
+        private Integer seDnvCnt;
+
+        @JsonProperty("sl_dnv_cnt")
+        private Integer slDnvCnt;
+
+        @JsonProperty("wnd_dnv_cnt")
+        private Integer wndDnvCnt;
+
+        @JsonProperty("geom_json")
+        private String geomJson;
+
+        @JsonProperty("lo_crd")
+        private String loCrd;   // "127.0..." 문자열로 옴
+
+        @JsonProperty("la_crd")
+        private String laCrd;   // "37.6..." 문자열
+    }
+
+    // 편의 메서드
+    public List<Item> getItemList() {
+        if (items == null || items.item == null) return List.of();
+        return items.item;
+    }
+}

--- a/src/main/java/backend/knowhow/domain/alert/dto/internal/AlertItem.java
+++ b/src/main/java/backend/knowhow/domain/alert/dto/internal/AlertItem.java
@@ -14,7 +14,8 @@ public class AlertItem {
     public enum SourceType {
         TRAFFIC_EVENT,       // 돌발상황 (trafficEvent)
         CAUTION_SECTION,     // 주의운전구간 (cautionSection)
-        TRAFFIC_FLOW         // 소통정보 (trafficInfo)
+        TRAFFIC_FLOW,        // 소통정보 (trafficInfo)
+        ACCIDENT_SPOT        // 사고 다발 구역 (koroadRiskService)
     }
 
     private SourceType source;

--- a/src/main/java/backend/knowhow/domain/alert/mapper/KoroadHotspotMapper.java
+++ b/src/main/java/backend/knowhow/domain/alert/mapper/KoroadHotspotMapper.java
@@ -1,0 +1,48 @@
+package backend.knowhow.domain.alert.mapper;
+
+import backend.knowhow.domain.alert.domain.KoroadHotspot;
+import backend.knowhow.domain.alert.dto.internal.AlertItem;
+import backend.knowhow.domain.alert.util.DistanceCalculator;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class KoroadHotspotMapper {
+
+    private final DistanceCalculator distanceCalculator;
+
+    public AlertItem toAlert(
+            KoroadHotspot hotspot,
+            double userLat,
+            double userLon
+    ) {
+        double dist = distanceCalculator.calculate(
+                userLat, userLon,
+                hotspot.getLat(), hotspot.getLon()
+        );
+
+        int m = (int) Math.round(dist);
+
+        String typeLabel = switch (hotspot.getType()) {
+            case "OLD_MAN" -> "보행 노인 교통사고 다발지역";
+            case "CHILD" -> "보행 어린이 교통사고 다발지역";
+            case "SCHOOL" -> "어린이 보호구역 내 교통사고 다발지역";
+            default -> "교통사고 다발지역";
+        };
+
+        // 최종 음성 안내 문구
+        String msg = String.format(
+                "전방 %d미터 앞 %s %s입니다.",
+                m,
+                hotspot.getSidoSggName() != null ? hotspot.getSidoSggName() : "",
+                typeLabel
+        );
+
+        return AlertItem.builder()
+                .source(AlertItem.SourceType.ACCIDENT_SPOT)
+                .distance(dist)
+                .message(msg)
+                .build();
+    }
+}

--- a/src/main/java/backend/knowhow/domain/alert/repository/KoroadHotspotRepository.java
+++ b/src/main/java/backend/knowhow/domain/alert/repository/KoroadHotspotRepository.java
@@ -1,0 +1,15 @@
+package backend.knowhow.domain.alert.repository;
+
+import backend.knowhow.domain.alert.domain.KoroadHotspot;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface KoroadHotspotRepository extends JpaRepository<KoroadHotspot, Long> {
+
+    List<KoroadHotspot> findByType(String type);
+
+    List<KoroadHotspot> findByTypeAndSiDoAndGuGun(String type, Integer siDo, Integer guGun);
+
+    void deleteByTypeAndSiDoAndGuGun(String type, Integer siDo, Integer guGun);
+}

--- a/src/main/java/backend/knowhow/domain/alert/service/AlertCollector.java
+++ b/src/main/java/backend/knowhow/domain/alert/service/AlertCollector.java
@@ -21,6 +21,7 @@ public class AlertCollector {
 
     private final CautionSectionApiClient cautionSectionApiClient;
     private final CautionSectionMapper cautionSectionMapper;
+    private final KoroadAlertCollector koroadAlertCollector;
 
     public List<AlertItem> collect(double lat, double lon, double rangeKm) {
 
@@ -39,11 +40,15 @@ public class AlertCollector {
             var cautionSections = cautionSectionApiClient.fetchCautionSections(minX, maxX, minY, maxY);
             var cautionAlerts = cautionSectionMapper.toAlerts(cautionSections, lat, lon);
 
+            // 3) Koroad 사고다발지역
+            var koroadAlerts = koroadAlertCollector.collect(lat, lon, rangeKm);
+
             log.info("Collected events={}, cautions={}",
                     eventAlerts.size(), cautionAlerts.size());
 
             List<AlertItem> combined = new java.util.ArrayList<>(eventAlerts);
             combined.addAll(cautionAlerts);
+            combined.addAll(koroadAlerts);
             return combined;
 
         } catch (Exception e) {

--- a/src/main/java/backend/knowhow/domain/alert/service/KoroadAlertCollector.java
+++ b/src/main/java/backend/knowhow/domain/alert/service/KoroadAlertCollector.java
@@ -1,0 +1,63 @@
+package backend.knowhow.domain.alert.service;
+
+import backend.knowhow.domain.alert.domain.KoroadHotspot;
+import backend.knowhow.domain.alert.dto.internal.AlertItem;
+import backend.knowhow.domain.alert.mapper.KoroadHotspotMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.Point;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class KoroadAlertCollector {
+
+    private final KoroadHotspotGeometryCache cache;
+    private final KoroadHotspotMapper mapper;
+    private final GeometryFactory geometryFactory = new GeometryFactory();
+
+    // Koroad 사고 다발지역 기반 AlertItem 수집
+    public List<AlertItem> collect(double userLat, double userLon, double rangeKm) {
+
+        List<AlertItem> result = new ArrayList<>();
+
+        double maxDistanceM = rangeKm * 1000.0;
+        Point userPoint = geometryFactory.createPoint(new Coordinate(userLon, userLat));
+
+        for (KoroadHotspotGeometryCache.CachedHotspot ch : cache.getHotspots()) {
+
+            KoroadHotspot hotspot = ch.getEntity();
+
+            // 1) 중심점 기준으로 반경 필터 (빠른 1차 필터)
+            AlertItem alert = mapper.toAlert(hotspot, userLat, userLon);
+            if (alert.getDistance() > maxDistanceM) {
+                continue;
+            }
+
+            // 2) 폴리곤 내부/근접 여부 체크 (정확한 판정)
+            //    "폴리곤 안에 들어가면"만 보내고 싶으면 이 조건 유지
+            //    "폴리곤 근처여도 보내고 싶다"면 이 조건을 완화해도 됨
+            if (!ch.getGeometry().contains(userPoint) &&
+                    !ch.getGeometry().covers(userPoint)) {
+                // 근처지만 폴리곤 밖이면, 정책에 따라:
+                // - 근접도 알림: 이 if 블록 제거
+                // - 엄밀히 내부만: 지금처럼 continue
+                continue;
+            }
+
+            log.info("[KoroadAlertCollector] INSIDE polygon: hotspotId={}, name={}, dist={}m",
+                    hotspot.getId(), hotspot.getSpotName(), alert.getDistance());
+
+            result.add(alert);
+        }
+
+        log.info("[KoroadAlertCollector] collected {} koroad alerts", result.size());
+        return result;
+    }
+}

--- a/src/main/java/backend/knowhow/domain/alert/service/KoroadHotspotGeometryCache.java
+++ b/src/main/java/backend/knowhow/domain/alert/service/KoroadHotspotGeometryCache.java
@@ -29,6 +29,12 @@ public class KoroadHotspotGeometryCache {
 
     @PostConstruct
     public void loadFromDb() {
+        reloadCache();
+    }
+
+    public synchronized void reloadCache() {
+        hotspots.clear();
+
         List<KoroadHotspot> all = hotspotRepository.findAll();
         int success = 0;
 

--- a/src/main/java/backend/knowhow/domain/alert/service/KoroadHotspotGeometryCache.java
+++ b/src/main/java/backend/knowhow/domain/alert/service/KoroadHotspotGeometryCache.java
@@ -1,0 +1,65 @@
+package backend.knowhow.domain.alert.service;
+
+import backend.knowhow.domain.alert.domain.KoroadHotspot;
+import backend.knowhow.domain.alert.repository.KoroadHotspotRepository;
+import jakarta.annotation.PostConstruct;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.io.geojson.GeoJsonReader;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class KoroadHotspotGeometryCache {
+
+    private final KoroadHotspotRepository hotspotRepository;
+
+    private final GeometryFactory geometryFactory = new GeometryFactory();
+    private final GeoJsonReader geoJsonReader = new GeoJsonReader(geometryFactory);
+
+    @Getter
+    private final List<CachedHotspot> hotspots = new ArrayList<>();
+
+    @PostConstruct
+    public void loadFromDb() {
+        List<KoroadHotspot> all = hotspotRepository.findAll();
+        int success = 0;
+
+        for (KoroadHotspot entity : all) {
+            String geomJson = entity.getGeomJson();
+            if (geomJson == null || geomJson.isBlank()) {
+                continue;
+            }
+
+            try {
+                Geometry geom = geoJsonReader.read(geomJson); // GeoJSON → Geometry
+                hotspots.add(new CachedHotspot(entity, geom));
+                success++;
+            } catch (Exception e) {
+                log.warn("[KoroadHotspotGeometryCache] parse error id={}, msg={}",
+                        entity.getId(), e.getMessage());
+            }
+        }
+
+        log.info("[KoroadHotspotGeometryCache] loaded {} entities, {} geometries parsed.",
+                all.size(), success);
+    }
+
+    @Getter
+    public static class CachedHotspot {
+        private final KoroadHotspot entity;
+        private final Geometry geometry;
+
+        public CachedHotspot(KoroadHotspot entity, Geometry geometry) {
+            this.entity = entity;
+            this.geometry = geometry;
+        }
+    }
+}

--- a/src/main/java/backend/knowhow/domain/alert/service/KoroadHotspotSyncService.java
+++ b/src/main/java/backend/knowhow/domain/alert/service/KoroadHotspotSyncService.java
@@ -25,6 +25,11 @@ public class KoroadHotspotSyncService {
         // Koroad에서 신규 데이터 가져오기
         List<KoroadBaseResponse.Item> items = koroadApiClient.fetchHotspots(apiType, siDo, guGun);
 
+        if (items.isEmpty()) {
+            log.warn("[KoroadHotspotSyncService] No items fetched. Skipping sync for type={}, siDo={}, guGun={}", type, siDo, guGun);
+            return;
+        }
+
         // 기존 데이터 삭제 (같은 type + region 기준)
         hotspotRepository.deleteByTypeAndSiDoAndGuGun(type, siDo, guGun);
 

--- a/src/main/java/backend/knowhow/domain/alert/service/KoroadHotspotSyncService.java
+++ b/src/main/java/backend/knowhow/domain/alert/service/KoroadHotspotSyncService.java
@@ -1,0 +1,64 @@
+package backend.knowhow.domain.alert.service;
+
+import backend.knowhow.domain.alert.client.KoroadApiClient;
+import backend.knowhow.domain.alert.domain.KoroadHotspot;
+import backend.knowhow.domain.alert.dto.external.KoroadBaseResponse;
+import backend.knowhow.domain.alert.repository.KoroadHotspotRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class KoroadHotspotSyncService {
+
+    private final KoroadApiClient koroadApiClient;
+    private final KoroadHotspotRepository hotspotRepository;
+
+    // Koroad API → MySQL 저장 (해당 type + 시/도 + 구/군 기준으로 전체 갱신)
+    @Transactional
+    public void syncHotspots(String apiType, String type, Integer siDo, Integer guGun) {
+        // Koroad에서 신규 데이터 가져오기
+        List<KoroadBaseResponse.Item> items = koroadApiClient.fetchHotspots(apiType, siDo, guGun);
+
+        // 기존 데이터 삭제 (같은 type + region 기준)
+        hotspotRepository.deleteByTypeAndSiDoAndGuGun(type, siDo, guGun);
+
+        // 3) 새 데이터 저장
+        List<KoroadHotspot> entities = items.stream()
+                .map(item -> {
+                    Double lat = null;
+                    Double lon = null;
+
+                    try {
+                        if (item.getLaCrd() != null)
+                            lat = Double.parseDouble(item.getLaCrd());
+                        if (item.getLoCrd() != null)
+                            lon = Double.parseDouble(item.getLoCrd());
+                    } catch (NumberFormatException e) {
+                        log.warn("[KoroadHotspotSyncService] invalid coord la={}, lo={}",
+                                item.getLaCrd(), item.getLoCrd());
+                    }
+
+                    return KoroadHotspot.builder()
+                            .type(type)
+                            .afosFid(item.getAfosId())
+                            .spotName(item.getSpotName())
+                            .sidoSggName(item.getSidoSggName())
+                            .siDo(siDo)
+                            .guGun(guGun)
+                            .accidentCount(item.getAccidentCount())
+                            .lat(lat)
+                            .lon(lon)
+                            .geomJson(item.getGeomJson())
+                            .build();
+                })
+                .toList();
+
+        hotspotRepository.saveAll(entities);
+    }
+}

--- a/src/main/java/backend/knowhow/domain/alert/service/KoroadRiskService.java
+++ b/src/main/java/backend/knowhow/domain/alert/service/KoroadRiskService.java
@@ -1,0 +1,38 @@
+//package backend.knowhow.domain.alert.service;
+//
+//import backend.knowhow.domain.alert.domain.KoroadHotspot;
+//import lombok.RequiredArgsConstructor;
+//import lombok.extern.slf4j.Slf4j;
+//import org.locationtech.jts.geom.Coordinate;
+//import org.locationtech.jts.geom.GeometryFactory;
+//import org.locationtech.jts.geom.Point;
+//import org.springframework.stereotype.Service;
+//
+//import java.util.Optional;
+//
+//@Service
+//@Slf4j
+//@RequiredArgsConstructor
+//public class KoroadRiskService {
+//
+//    private final KoroadHotspotGeometryCache cache;
+//    private final GeometryFactory geometryFactory = new GeometryFactory();
+//
+//    // 현재 위치가 Koroad hotspot 폴리곤 안에 들어가는지 여부
+//    public Optional<KoroadHotspot> findContaining(double lat, double lon) {
+//        Point point = geometryFactory.createPoint(new Coordinate(lon, lat)); // x=lon, y=lat
+//
+//        for (KoroadHotspotGeometryCache.CachedHotspot ch : cache.getHotspots()) {
+//            if (ch.getGeometry().contains(point) || ch.getGeometry().covers(point)) {
+//                log.info("inside risk!!!!");
+//                return Optional.of(ch.getEntity());
+//            }
+//        }
+//        return Optional.empty();
+//    }
+//
+//    public boolean isInside(double lat, double lon) {
+//        return findContaining(lat, lon).isPresent();
+//    }
+//}
+//


### PR DESCRIPTION
## 🚘 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요. 
- [x] 교통사고 다발지역 api 연결 ([https://opendata.koroad.or.kr/api/main.do](https://opendata.koroad.or.kr/api/main.do))
- [x] 웹소켓 이어서 연결

## #️⃣ 테스트 내용
> 어떤 테스트를 수행했는지 명시해주세요.  
- [x] Postman 테스트
- [ ] 단위 테스트 수행
- [ ] 통합 테스트 수행
- [x] [https://jiangxy.github.io/websocket-debug-tool/](https://jiangxy.github.io/websocket-debug-tool/) 사용

## 🚧 구현 중 겪은 이슈 및 해결 방법
> 구현 과정에서 발생한 문제나 오류, 그리고 이를 어떻게 해결했는지 간략히 작성해주세요.

https://opendata.koroad.or.kr/api/main.do 이 사이트 api키 작동이 안되어요....... ㅠㅠ
공공데이터 포털에서 다시 받아옴

## 🔍 참고 사항
> 코드 리뷰 시 참고해야 할 내용이나 추가적으로 공유할 사항이 있다면 작성해주세요.

실시간인데 매번 api를 호출해서 불러오기에는 너무 느릴 것 같아서 db에 저장해두고, 서버 시작될 때 마다 메모리에 저장되게끔 해두었습니다.
POST /koroad/sync/seoul
로 우선 서울지역만 db에 저장해놓겠습니다. 추후 다른 지역까지 확장하겠습니다.

## 🔗 관련 이슈
- closes #13 
---


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 사고 다발지역(ACCIDENT_SPOT) 기반 실시간 알림 수집 및 변환 추가
  * 서울 전체 구 단위 사고 다발지역 동기화용 POST 엔드포인트 추가
  * 동기화·캐시 기반의 공간(폴리곤) 데이터 로드 및 조회 기능 추가

* **개선**
  * 반경·폴리곤 기반 필터링으로 위치별 알림 정확도 향상
  * 동기화 시 기존 데이터 교체 및 안전한 좌표 파싱 처리 적용

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->