### PR TITLE
[Feat] 사용자 환경설정 저장

### DIFF
--- a/src/main/java/backend/knowhow/domain/member/controller/MemberController.java
+++ b/src/main/java/backend/knowhow/domain/member/controller/MemberController.java
@@ -1,10 +1,13 @@
 package backend.knowhow.domain.member.controller;
 
 import backend.knowhow.domain.member.dto.request.ConnectRequest;
+import backend.knowhow.domain.member.dto.request.DeviceSettingRequest;
 import backend.knowhow.domain.member.dto.response.ConnectionCodeResponse;
+import backend.knowhow.domain.member.dto.response.DeviceSettingResponse;
 import backend.knowhow.domain.member.dto.response.MemberInfoResponse;
 import backend.knowhow.domain.member.service.ConnectionCodeService;
 import backend.knowhow.domain.member.service.GuardianLinkService;
+import backend.knowhow.domain.member.service.MemberDeviceSettingService;
 import backend.knowhow.domain.member.service.MemberService;
 import backend.knowhow.global.common.response.ApiResponse;
 import backend.knowhow.global.security.CurrentUser;
@@ -21,6 +24,7 @@ public class MemberController {
     private final MemberService memberService;
     private final ConnectionCodeService connectionCodeService;
     private final GuardianLinkService guardianLinkService;
+    private final MemberDeviceSettingService settingService;
 
     @GetMapping("/me")
     public ApiResponse<MemberInfoResponse> getMyInfo(@CurrentUser MemberPrincipal user) {
@@ -49,6 +53,22 @@ public class MemberController {
         connectionCodeService.deleteCode(request.code());
 
         return ApiResponse.success();
+    }
+
+    @PostMapping("/device-setting")
+    public DeviceSettingResponse saveOrUpdateSetting(
+            @CurrentUser MemberPrincipal member,
+            @RequestBody DeviceSettingRequest request
+    ) {
+        return settingService.saveOrUpdateSetting(member.getId(), request);
+    }
+
+    @GetMapping("/device-setting/{deviceId}")
+    public DeviceSettingResponse getSetting(
+            @CurrentUser MemberPrincipal member,
+            @PathVariable String deviceId
+    ) {
+        return settingService.getSetting(member.getId(), deviceId);
     }
 
 }

--- a/src/main/java/backend/knowhow/domain/member/controller/MemberController.java
+++ b/src/main/java/backend/knowhow/domain/member/controller/MemberController.java
@@ -12,6 +12,7 @@ import backend.knowhow.domain.member.service.MemberService;
 import backend.knowhow.global.common.response.ApiResponse;
 import backend.knowhow.global.security.CurrentUser;
 import backend.knowhow.global.security.MemberPrincipal;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
@@ -58,7 +59,7 @@ public class MemberController {
     @PostMapping("/device-setting")
     public DeviceSettingResponse saveOrUpdateSetting(
             @CurrentUser MemberPrincipal member,
-            @RequestBody DeviceSettingRequest request
+            @Valid @RequestBody DeviceSettingRequest request
     ) {
         return settingService.saveOrUpdateSetting(member.getId(), request);
     }

--- a/src/main/java/backend/knowhow/domain/member/domain/MemberDeviceSetting.java
+++ b/src/main/java/backend/knowhow/domain/member/domain/MemberDeviceSetting.java
@@ -1,0 +1,63 @@
+package backend.knowhow.domain.member.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Table(
+        name = "member_device_setting",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_member_device",
+                        columnNames = {"member_id", "device_id"}
+                )
+        }
+)
+public class MemberDeviceSetting {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    // 기기 식별자 (디바이스 ID, FCM token, UUID 등)
+    @Column(name = "device_id", nullable = false, length = 100)
+    private String deviceId;
+
+    // 글자 크기 (1~3), 기본 2
+    @Column(name = "font_level", nullable = false)
+    private int fontLevel;
+
+    // 소리 크기 (1~3), 기본 2
+    @Column(name = "volume_level", nullable = false)
+    private int volumeLevel;
+
+    @Builder
+    public MemberDeviceSetting(Member member, String deviceId, int fontLevel, int volumeLevel){
+        this.member = member;
+        this.deviceId = deviceId;
+        this.fontLevel = fontLevel;
+        this.volumeLevel = volumeLevel;
+    }
+
+    // 값 수정 메서드 (범위 체크 포함)
+    public void changeLevels(int fontLevel, int volumeLevel) {
+        validateLevel(fontLevel, "fontLevel");
+        validateLevel(volumeLevel, "volumeLevel");
+
+        this.fontLevel = fontLevel;
+        this.volumeLevel = volumeLevel;
+    }
+
+    private void validateLevel(int level, String fieldName) {
+        if (level < 1 || level > 3) {
+            throw new IllegalArgumentException(fieldName + " must be between 1 and 3. input=" + level);
+        }
+    }
+}

--- a/src/main/java/backend/knowhow/domain/member/dto/request/DeviceSettingRequest.java
+++ b/src/main/java/backend/knowhow/domain/member/dto/request/DeviceSettingRequest.java
@@ -1,0 +1,13 @@
+package backend.knowhow.domain.member.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record DeviceSettingRequest(
+        @NotBlank
+        String deviceId,
+
+        // null이면 기본값 2로 처리
+        Integer fontLevel,
+        Integer volumeLevel
+) {
+}

--- a/src/main/java/backend/knowhow/domain/member/dto/response/DeviceSettingResponse.java
+++ b/src/main/java/backend/knowhow/domain/member/dto/response/DeviceSettingResponse.java
@@ -1,0 +1,17 @@
+package backend.knowhow.domain.member.dto.response;
+
+import backend.knowhow.domain.member.domain.MemberDeviceSetting;
+
+public record DeviceSettingResponse(
+        String deviceId,
+        int fontLevel,
+        int volumeLevel
+) {
+    public static DeviceSettingResponse from(MemberDeviceSetting setting) {
+        return new DeviceSettingResponse(setting.getDeviceId(), setting.getFontLevel(), setting.getVolumeLevel());
+    }
+
+    public static DeviceSettingResponse from(String deviceId, int fontLevel, int volumeLevel) {
+        return new DeviceSettingResponse(deviceId, fontLevel, volumeLevel);
+    }
+}

--- a/src/main/java/backend/knowhow/domain/member/repository/MemberDeviceSettingRepository.java
+++ b/src/main/java/backend/knowhow/domain/member/repository/MemberDeviceSettingRepository.java
@@ -1,0 +1,12 @@
+package backend.knowhow.domain.member.repository;
+
+import backend.knowhow.domain.member.domain.Member;
+import backend.knowhow.domain.member.domain.MemberDeviceSetting;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface MemberDeviceSettingRepository extends JpaRepository<MemberDeviceSetting, Long> {
+
+    Optional<MemberDeviceSetting> findByMemberAndDeviceId(Member member, String deviceId);
+}

--- a/src/main/java/backend/knowhow/domain/member/service/MemberDeviceSettingService.java
+++ b/src/main/java/backend/knowhow/domain/member/service/MemberDeviceSettingService.java
@@ -34,8 +34,8 @@ public class MemberDeviceSettingService {
                         MemberDeviceSetting.builder()
                                 .member(member)
                                 .deviceId(request.deviceId())
-                                .volumeLevel(request.volumeLevel())
-                                .fontLevel(request.fontLevel())
+                                .volumeLevel(volumeLevel)
+                                .fontLevel(fontLevel)
                                 .build()
                 );
 

--- a/src/main/java/backend/knowhow/domain/member/service/MemberDeviceSettingService.java
+++ b/src/main/java/backend/knowhow/domain/member/service/MemberDeviceSettingService.java
@@ -1,0 +1,62 @@
+package backend.knowhow.domain.member.service;
+
+import backend.knowhow.domain.member.domain.Member;
+import backend.knowhow.domain.member.domain.MemberDeviceSetting;
+import backend.knowhow.domain.member.dto.request.DeviceSettingRequest;
+import backend.knowhow.domain.member.dto.response.DeviceSettingResponse;
+import backend.knowhow.domain.member.repository.MemberDeviceSettingRepository;
+import backend.knowhow.domain.member.repository.MemberRepository;
+import backend.knowhow.global.common.exception.BaseException;
+import backend.knowhow.global.common.response.ErrorType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class MemberDeviceSettingService {
+
+    private final MemberDeviceSettingRepository settingRepository;
+    private final MemberRepository memberRepository;
+    
+    @Transactional
+    public DeviceSettingResponse saveOrUpdateSetting(Long memberId, DeviceSettingRequest request) {
+        int fontLevel = request.fontLevel() == null ? 2 : request.fontLevel();  // null값이면 2로 기본 설정
+        int volumeLevel = request.volumeLevel() == null ? 2 : request.volumeLevel();
+
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new BaseException(ErrorType.MEMBER_NOT_FOUND));
+
+        // 설정이 없으면 새로 생성
+        MemberDeviceSetting setting = settingRepository
+                .findByMemberAndDeviceId(member, request.deviceId())
+                .orElseGet(() ->
+                        MemberDeviceSetting.builder()
+                                .member(member)
+                                .deviceId(request.deviceId())
+                                .volumeLevel(request.volumeLevel())
+                                .fontLevel(request.fontLevel())
+                                .build()
+                );
+
+        // 설정이 이미 있으면 덮어쓰기 (fontLevel, volumeLevel 모두 교체)
+        setting.changeLevels(fontLevel, volumeLevel);
+
+        // 새로 만든 경우든, 수정한 경우든 save
+        MemberDeviceSetting saved = settingRepository.save(setting);
+
+        return DeviceSettingResponse.from(saved);
+    }
+
+    // 세팅 조회
+    @Transactional(readOnly = true)
+    public DeviceSettingResponse getSetting(Long memberId, String deviceId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new BaseException(ErrorType.MEMBER_NOT_FOUND));
+
+        return settingRepository.findByMemberAndDeviceId(member, deviceId)
+                .map(setting -> DeviceSettingResponse.from(setting))
+                // DB에 없으면 기본값(2,2)로 응답 (DB에 저장은 안 함)
+                .orElseGet(() -> DeviceSettingResponse.from(deviceId, 2, 2));
+    }
+}


### PR DESCRIPTION
## 🚘 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요. 
- [x] 사용자 환경설정(음량, 글씨 크기) 저장
- [x] 사용자 환경설정(음량, 글씨 크기) 조회

## #️⃣ 테스트 내용
> 어떤 테스트를 수행했는지 명시해주세요.  
- [x] Postman 테스트
- [ ] 단위 테스트 수행
- [ ] 통합 테스트 수행

## 🔗 관련 이슈
- closes #20 
---


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 기기별 사용자 설정 관리 기능 추가: 각 기기에 대해 글자 크기(font)와 음량(volume) 레벨을 저장·조회할 수 있습니다.
  * 저장/수정: 특정 기기 설정을 저장하거나 업데이트할 수 있으며 입력값은 1~3 범위로 검증됩니다.
  * 조회: 저장된 설정을 불러오며 설정이 없으면 기본값(font=2, volume=2)을 반환합니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->