### PR TITLE
[Feat] 운전점수 기반 챌린지 미션 구현

### DIFF
--- a/src/main/java/backend/knowhow/domain/driving/service/DrivingService.java
+++ b/src/main/java/backend/knowhow/domain/driving/service/DrivingService.java
@@ -14,6 +14,8 @@ import backend.knowhow.domain.driving.service.weather.KmaWeatherClient;
 import backend.knowhow.domain.driving.service.weather.WeatherConditionMapper;
 import backend.knowhow.domain.member.domain.Member;
 import backend.knowhow.domain.member.repository.MemberRepository;
+import backend.knowhow.domain.mission.domain.MissionCode;
+import backend.knowhow.domain.mission.service.MissionService;
 import backend.knowhow.global.common.exception.BaseException;
 import backend.knowhow.global.common.response.ErrorType;
 import lombok.RequiredArgsConstructor;
@@ -26,7 +28,6 @@ import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.util.List;
 import java.util.Objects;
-import java.util.OptionalDouble;
 import java.util.stream.Collectors;
 
 @Service
@@ -39,6 +40,7 @@ public class DrivingService {
     private final DrivingSessionRepository drivingSessionRepository;
     private final MemberRepository memberRepository;
     private final WeatherConditionMapper weatherConditionMapper;
+    private final MissionService missionService;
 
     private static final LocalTime NIGHT_START = LocalTime.of(20, 0);   // 20:00
     private static final LocalTime NIGHT_END = LocalTime.of(6, 0);  // 6:00
@@ -84,6 +86,9 @@ public class DrivingService {
         Member driver = memberRepository.findById(memberId)
                 .orElseThrow(() -> new BaseException(ErrorType.MEMBER_NOT_FOUND));
 
+        // 운전 시작 시 챌린지형 미션 리셋
+        missionService.resetChallengeMissionsForDrive(driver);
+
         DrivingSession drive = DrivingSession.start(driver, request.getLat(), request.getLon());
         DrivingSession saveDrive = drivingSessionRepository.save(drive);
         return new DriveStartResponse(saveDrive.getId(), saveDrive.getStartTime());
@@ -108,6 +113,8 @@ public class DrivingService {
 
         driveSession.finish(request.getTotalDistance(), request.getHardAccelCount(), request.getHardDecelCount(),
                 request.getLat(), request.getLon(), driveScore);
+
+        checkDriveChallengeMission(driver, driveSession);
 
         return DrivingSessionSummary.from(driveSession);
     }
@@ -182,4 +189,27 @@ public class DrivingService {
         else if(ratePer100km <= 14.0) return 2;
         else return 1;
     }
+
+    // 단일 주행 미션 판정
+    private void checkDriveChallengeMission(Member driver, DrivingSession drivingSession) {
+        int score = drivingSession.getScore();
+        double distance = drivingSession.getDistance();
+        Long drivingSessionId = drivingSession.getId();
+
+        if (score < 80) {
+            return;
+        }
+        if (distance >= 30) {
+            missionService.completeChallengeMission(driver, MissionCode.DRIVE_30KM_SAFE, drivingSessionId);
+            return;
+        }
+        if (distance >= 20) {
+            missionService.completeChallengeMission(driver, MissionCode.DRIVE_20KM_SAFE, drivingSessionId);
+            return;
+        }
+        if (distance >= 10) {
+            missionService.completeChallengeMission(driver, MissionCode.DRIVE_10KM_SAFE, drivingSessionId);
+        }
+    }
+
 }

--- a/src/main/java/backend/knowhow/domain/member/service/GuardianLinkService.java
+++ b/src/main/java/backend/knowhow/domain/member/service/GuardianLinkService.java
@@ -39,8 +39,8 @@ public class GuardianLinkService {
         GuardianLink link = new GuardianLink(guardian, senior);
         guardianLinkRepository.save(link);
 
-        missionService.completeMission(senior, MissionCode.LINK_GUARDIAN);
-        missionService.completeMission(guardian, MissionCode.LINK_GUARDIAN);
+        missionService.completeAchievementMission(senior, MissionCode.LINK_GUARDIAN);
+        missionService.completeAchievementMission(guardian, MissionCode.LINK_GUARDIAN);
 
     }
 

--- a/src/main/java/backend/knowhow/domain/mission/domain/MemberMission.java
+++ b/src/main/java/backend/knowhow/domain/mission/domain/MemberMission.java
@@ -8,6 +8,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.util.Objects;
 
 @Entity
 @Getter
@@ -54,7 +55,7 @@ public class MemberMission {
     // 챌린지형 미션 달성
     public void completeChallenge(Long drivingSessionId) {
         // 같은 주행세션 중복 평가 방지
-        if (drivingSessionId.equals(this.lastEvaluatedDrivingSessionId)) {
+        if (Objects.equals(drivingSessionId, this.lastEvaluatedDrivingSessionId)) {
             return;
         }
         this.status = MissionStatus.COMPLETED;

--- a/src/main/java/backend/knowhow/domain/mission/domain/MemberMission.java
+++ b/src/main/java/backend/knowhow/domain/mission/domain/MemberMission.java
@@ -53,6 +53,7 @@ public class MemberMission {
 
     // 챌린지형 미션 달성
     public void completeChallenge(Long drivingSessionId) {
+        // 같은 주행세션 중복 평가 방지
         if (drivingSessionId.equals(this.lastEvaluatedDrivingSessionId)) {
             return;
         }

--- a/src/main/java/backend/knowhow/domain/mission/domain/MemberMission.java
+++ b/src/main/java/backend/knowhow/domain/mission/domain/MemberMission.java
@@ -37,15 +37,37 @@ public class MemberMission {
     @Column(nullable = false)
     private MissionStatus status;
 
+    // 운전 챌린지 미션일 경우 마지막으로 평가된 운전 세션 ID
+    private Long lastEvaluatedDrivingSessionId;
+
     private LocalDateTime completedAt; // 조건 달성 시점
     private LocalDateTime receivedAt;  // 포인트 수령 시점
 
-    // 미션 달성
-    public void complete() {
+    // 도전과제형(1회성) 미션 달성
+    public void completeAchievement() {
         if (this.status == MissionStatus.INCOMPLETE) {
             this.status = MissionStatus.COMPLETED;
             this.completedAt = LocalDateTime.now();
         }
+    }
+
+    // 챌린지형 미션 달성
+    public void completeChallenge(Long drivingSessionId) {
+        if (drivingSessionId.equals(this.lastEvaluatedDrivingSessionId)) {
+            return;
+        }
+        this.status = MissionStatus.COMPLETED;
+        this.completedAt = LocalDateTime.now();
+        this.lastEvaluatedDrivingSessionId = drivingSessionId;
+    }
+
+    // 챌린지형 미션 초기화
+    public void resetChallenge() {
+        if (this.status == MissionStatus.INCOMPLETE) return;
+        this.status = MissionStatus.INCOMPLETE;
+        this.completedAt = null;
+        this.receivedAt = null;
+        this.lastEvaluatedDrivingSessionId = null;
     }
 
     // 포인트 수령

--- a/src/main/java/backend/knowhow/domain/mission/domain/MemberMission.java
+++ b/src/main/java/backend/knowhow/domain/mission/domain/MemberMission.java
@@ -55,7 +55,7 @@ public class MemberMission {
     // 챌린지형 미션 달성
     public void completeChallenge(Long drivingSessionId) {
         // 같은 주행세션 중복 평가 방지
-        if (Objects.equals(drivingSessionId, this.lastEvaluatedDrivingSessionId)) {
+        if (drivingSessionId != null && drivingSessionId.equals(this.lastEvaluatedDrivingSessionId)) {
             return;
         }
         this.status = MissionStatus.COMPLETED;

--- a/src/main/java/backend/knowhow/domain/mission/domain/Mission.java
+++ b/src/main/java/backend/knowhow/domain/mission/domain/Mission.java
@@ -24,14 +24,19 @@ public class Mission {
     @Column(nullable = false, unique = true)
     private MissionCode code;
 
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private MissionType type;
+
     @Column(nullable = false, length = 500)
     private String detail;
 
-    public static Mission createMission(String title, int rewardPoint, MissionCode code, String detail) {
+    public static Mission createMission(String title, int rewardPoint, MissionCode code, MissionType missionType,String detail) {
         Mission mission = new Mission();
         mission.title = title;
         mission.rewardPoint = rewardPoint;
         mission.code = code;
+        mission.type = missionType;
         mission.detail = detail;
         return mission;
     }

--- a/src/main/java/backend/knowhow/domain/mission/domain/MissionCode.java
+++ b/src/main/java/backend/knowhow/domain/mission/domain/MissionCode.java
@@ -2,7 +2,7 @@ package backend.knowhow.domain.mission.domain;
 
 public enum MissionCode {
     LINK_GUARDIAN,
-    DRIVE_10KM,
-    DRIVE_20KM,
-    DRIVE_30KM
+    DRIVE_10KM_SAFE,
+    DRIVE_20KM_SAFE,
+    DRIVE_30KM_SAFE
 }

--- a/src/main/java/backend/knowhow/domain/mission/domain/MissionType.java
+++ b/src/main/java/backend/knowhow/domain/mission/domain/MissionType.java
@@ -1,0 +1,6 @@
+package backend.knowhow.domain.mission.domain;
+
+public enum MissionType {
+    ACHIEVEMENT,
+    CHALLENGE
+}

--- a/src/main/java/backend/knowhow/domain/mission/service/MissionService.java
+++ b/src/main/java/backend/knowhow/domain/mission/service/MissionService.java
@@ -66,18 +66,14 @@ public class MissionService {
 
     @Transactional
     public void completeChallengeMission(Member member, MissionCode missionCode, Long drivingSessionId) {
-        Member managedMember = memberRepository.findById(member.getId())
-                .orElseThrow(() -> new BaseException(ErrorType.MEMBER_NOT_FOUND));
-
-
         Mission mission = missionRepository.findByCode(missionCode)
                 .orElseThrow(() -> new BaseException(ErrorType.MISSION_NOT_FOUND));
 
         MemberMission memberMission =
-                memberMissionRepository.findByMemberAndMission(managedMember, mission)
+                memberMissionRepository.findByMemberAndMission(member, mission)
                         .orElseGet(() ->
                                 memberMissionRepository.save(
-                                        MemberMission.createNew(managedMember, mission)
+                                        MemberMission.createNew(member, mission)
                                 )
                         );
 

--- a/src/main/java/backend/knowhow/domain/mission/service/MissionService.java
+++ b/src/main/java/backend/knowhow/domain/mission/service/MissionService.java
@@ -9,7 +9,6 @@ import backend.knowhow.domain.mission.repository.MissionRepository;
 import backend.knowhow.global.common.exception.BaseException;
 import backend.knowhow.global.common.response.ErrorType;
 import lombok.RequiredArgsConstructor;
-import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -46,8 +45,27 @@ public class MissionService {
     }
 
     @Transactional
-    public void completeMission(Member member, MissionCode missionCode) {
-        // 재조회 : 외부에서 넘어온 Member 객체는 영속성 컨텍스트에 없을 수 있으므로(detached 상태) managed entity 보장하기 위함
+    public void completeAchievementMission(Member member, MissionCode missionCode) {
+        Mission mission = missionRepository.findByCode(missionCode)
+                .orElseThrow(() -> new BaseException(ErrorType.MISSION_NOT_FOUND));
+
+        MemberMission memberMission =
+                memberMissionRepository.findByMemberAndMission(member, mission)
+                        .orElseGet(() ->
+                                memberMissionRepository.save(
+                                        MemberMission.createNew(member, mission)
+                                )
+                        );
+
+        // 이미 포인트 받은 미션이면 종료
+        if (memberMission.getStatus() == MissionStatus.RECEIVED) {
+            return;
+        }
+        memberMission.completeAchievement();
+    }
+
+    @Transactional
+    public void completeChallengeMission(Member member, MissionCode missionCode, Long drivingSessionId) {
         Member managedMember = memberRepository.findById(member.getId())
                 .orElseThrow(() -> new BaseException(ErrorType.MEMBER_NOT_FOUND));
 
@@ -63,11 +81,12 @@ public class MissionService {
                                 )
                         );
 
-        // 이미 포인트 받은 미션이면 종료
-        if (memberMission.getStatus() == MissionStatus.RECEIVED) {
+        // 같은 주행세션 중복 평가 방지
+        if (memberMission.getLastEvaluatedDrivingSessionId() != null &&
+                drivingSessionId.equals(memberMission.getLastEvaluatedDrivingSessionId())) {
             return;
         }
-        memberMission.complete();
+        memberMission.completeChallenge(drivingSessionId);
     }
 
     @Transactional
@@ -93,5 +112,17 @@ public class MissionService {
 
         // 포인트 지급 및 내역 생성
         pointService.earnMissionReward(member, mission.getRewardPoint(), mission.getTitle());
+    }
+
+    @Transactional
+    public void resetChallengeMissionsForDrive(Member member) {
+        // 호출한 메서드의 @Transactional(Propagation.REQUIRED) 전파 범위 내에서 이미 영속화된 Member 객체가 넘어오므로 그대로 사용
+        List<MemberMission> missions =
+                memberMissionRepository.findAllByMemberWithMission(member);
+        for (MemberMission mm : missions) {
+            if (mm.getMission().getType() == MissionType.CHALLENGE) {
+                mm.resetChallenge();
+            }
+        }
     }
 }

--- a/src/main/java/backend/knowhow/domain/mission/service/MissionService.java
+++ b/src/main/java/backend/knowhow/domain/mission/service/MissionService.java
@@ -81,11 +81,6 @@ public class MissionService {
                                 )
                         );
 
-        // 같은 주행세션 중복 평가 방지
-        if (memberMission.getLastEvaluatedDrivingSessionId() != null &&
-                drivingSessionId.equals(memberMission.getLastEvaluatedDrivingSessionId())) {
-            return;
-        }
         memberMission.completeChallenge(drivingSessionId);
     }
 


### PR DESCRIPTION
<!--
name: PR 템플릿
about: PR 생성 시 이 템플릿을 사용해 주세요.
title: "[Feat]", "[Fix]", ..
-->
## 🚘 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요. 
- [x] 운전 종료 시 운전점수, 주행거리 기준으로 안전운전 미션 달성 여부를 판정
- [x] 미션 타입 분리 (1회성 미션/챌린지 미션)

## #️⃣ 테스트 내용
> 어떤 테스트를 수행했는지 명시해주세요.  
- [x] Postman 테스트
- [ ] 단위 테스트 수행
- [ ] 통합 테스트 수행


## 🔗 관련 이슈
- closes #40 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 안전 운전 거리(10km/20km/30km) 기반 운전 챌린지 추가
  * 미션을 성취(Achievement)와 챌린지(Challenge)로 분류
  * 운전 시작 시 챌린지 미션 자동 초기화
  * 운전 종료 시 점수(≥80)·거리 기준으로 챌린지 자동 평가 및 완료 처리
  * 일부 미션 명칭이 "SAFE" 표기로 갱신됨

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->