### PR TITLE
[Feat] 보호자 연동관계 해제 구현

### DIFF
--- a/src/main/java/backend/knowhow/domain/member/controller/MemberController.java
+++ b/src/main/java/backend/knowhow/domain/member/controller/MemberController.java
@@ -110,4 +110,12 @@ public class MemberController {
         );
     }
 
+    // 연동 해제하기
+    @PreAuthorize("hasAnyRole('GUARDIAN', 'SENIOR')")
+    @DeleteMapping("/link")
+    public ApiResponse<Void> unlink(@CurrentUser MemberPrincipal member) {
+        guardianLinkService.unlink(member.getId());
+        return ApiResponse.success();
+    }
+
 }

--- a/src/main/java/backend/knowhow/domain/member/service/GuardianLinkService.java
+++ b/src/main/java/backend/knowhow/domain/member/service/GuardianLinkService.java
@@ -103,4 +103,14 @@ public class GuardianLinkService {
                 reversed
         );
     }
+
+    @Transactional
+    public void unlink(Long memberId) {
+        GuardianLink link = guardianLinkRepository
+                .findByGuardianId(memberId)
+                .or(() -> guardianLinkRepository.findBySeniorId(memberId))
+                .orElseThrow(() -> new BaseException(ErrorType.LINK_NOT_FOUND));
+
+        guardianLinkRepository.delete(link);
+    }
 }


### PR DESCRIPTION
<!--
name: PR 템플릿
about: PR 생성 시 이 템플릿을 사용해 주세요.
title: "[Feat]", "[Fix]", ..
-->
## 🚘 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요. 
- [x] 보호자 연동 해제 API 
- [x] 보호자/고령자 모두 연동 해제 가능

## #️⃣ 테스트 내용
> 어떤 테스트를 수행했는지 명시해주세요.  
- [x] Postman 테스트
- [ ] 단위 테스트 수행
- [ ] 통합 테스트 수행


## 🔗 관련 이슈
- closes #24



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 신규 기능

* 보호자 및 피보호자 간의 연결 해제 기능이 추가되었습니다. 보호자 또는 피보호자 역할을 가진 사용자는 이제 기존 보호 관계를 원하는 시간에 해제할 수 있습니다. 사용자들은 개인의 상황과 필요에 맞게 보호 관계를 유연하게 관리하고 조정할 수 있게 되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->