### PR TITLE
[Fix] 회원탈퇴 시 pointHistory 내역 함께 삭제

### DIFF
--- a/src/main/java/backend/knowhow/domain/auth/service/AuthService.java
+++ b/src/main/java/backend/knowhow/domain/auth/service/AuthService.java
@@ -13,6 +13,7 @@ import backend.knowhow.domain.member.repository.MemberDeviceSettingRepository;
 import backend.knowhow.domain.member.repository.MemberRepository;
 import backend.knowhow.domain.auth.repository.RefreshTokenRepository;
 import backend.knowhow.domain.member.service.MemberDeviceSettingService;
+import backend.knowhow.domain.mission.repository.PointHistoryRepository;
 import backend.knowhow.global.common.exception.BaseException;
 import backend.knowhow.global.common.response.ErrorType;
 import backend.knowhow.global.security.jwt.JwtUtil;
@@ -31,6 +32,7 @@ public class AuthService {
     private final GuardianLinkRepository guardianLinkRepository;
     private final DrivingSessionRepository drivingSessionRepository;
     private final MemberDeviceSettingRepository memberDeviceSettingRepository;
+    private final PointHistoryRepository pointHistoryRepository;
     private final KakaoAuthService kakaoAuthService;
     private final GoogleAuthService googleAuthService;
     private final JwtUtil jwtUtil;
@@ -135,6 +137,7 @@ public class AuthService {
         guardianLinkRepository.deleteByGuardianIdOrSeniorId(memberId);
         drivingSessionRepository.deleteByDriver_Id(memberId);
         memberDeviceSettingRepository.deleteByMemberId(memberId);
+        pointHistoryRepository.deleteByMemberId(memberId);
         memberRepository.delete(member);
     }
 }

--- a/src/main/java/backend/knowhow/domain/mission/repository/PointHistoryRepository.java
+++ b/src/main/java/backend/knowhow/domain/mission/repository/PointHistoryRepository.java
@@ -12,4 +12,6 @@ import java.time.LocalDateTime;
 public interface PointHistoryRepository extends JpaRepository<PointHistory, Long> {
     // 월 범위로 조회
     Page<PointHistory> findAllByMemberAndCreatedAtGreaterThanEqualAndCreatedAtLessThan(Member member, LocalDateTime start, LocalDateTime end, Pageable pageable);
+
+    void deleteByMemberId(Long memberId);
 }


### PR DESCRIPTION
## 🚘 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요. 
- [x] 회원탈퇴 시 pointHistory 내역 함께 삭제

## #️⃣ 테스트 내용
> 어떤 테스트를 수행했는지 명시해주세요.  
- [x] Postman 테스트
- [ ] 단위 테스트 수행
- [ ] 통합 테스트 수행

## 🔗 관련 이슈
- closes #52
---


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 변경 사항

* **버그 수정**
  * 회원 탈퇴 시 관련 포인트 거래 기록이 자동으로 삭제됩니다. 계정 삭제 과정에서 포인트 데이터가 함께 정리되어 데이터 무결성이 개선됩니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->