### PR TITLE
[Fix] 회원탈퇴 시 member_mission 내역 함께 삭제

### DIFF
--- a/src/main/java/backend/knowhow/domain/auth/service/AuthService.java
+++ b/src/main/java/backend/knowhow/domain/auth/service/AuthService.java
@@ -13,6 +13,7 @@ import backend.knowhow.domain.member.repository.MemberDeviceSettingRepository;
 import backend.knowhow.domain.member.repository.MemberRepository;
 import backend.knowhow.domain.auth.repository.RefreshTokenRepository;
 import backend.knowhow.domain.member.service.MemberDeviceSettingService;
+import backend.knowhow.domain.mission.repository.MemberMissionRepository;
 import backend.knowhow.domain.mission.repository.PointHistoryRepository;
 import backend.knowhow.global.common.exception.BaseException;
 import backend.knowhow.global.common.response.ErrorType;
@@ -33,6 +34,7 @@ public class AuthService {
     private final DrivingSessionRepository drivingSessionRepository;
     private final MemberDeviceSettingRepository memberDeviceSettingRepository;
     private final PointHistoryRepository pointHistoryRepository;
+    private final MemberMissionRepository memberMissionRepository;
     private final KakaoAuthService kakaoAuthService;
     private final GoogleAuthService googleAuthService;
     private final JwtUtil jwtUtil;
@@ -138,6 +140,7 @@ public class AuthService {
         drivingSessionRepository.deleteByDriver_Id(memberId);
         memberDeviceSettingRepository.deleteByMemberId(memberId);
         pointHistoryRepository.deleteByMemberId(memberId);
+        memberMissionRepository.deleteByMemberId(memberId);
         memberRepository.delete(member);
     }
 }

--- a/src/main/java/backend/knowhow/domain/auth/service/AuthService.java
+++ b/src/main/java/backend/knowhow/domain/auth/service/AuthService.java
@@ -13,6 +13,7 @@ import backend.knowhow.domain.member.repository.MemberDeviceSettingRepository;
 import backend.knowhow.domain.member.repository.MemberRepository;
 import backend.knowhow.domain.auth.repository.RefreshTokenRepository;
 import backend.knowhow.domain.member.service.MemberDeviceSettingService;
+import backend.knowhow.domain.mission.repository.PointHistoryRepository;
 import backend.knowhow.global.common.exception.BaseException;
 import backend.knowhow.global.common.response.ErrorType;
 import backend.knowhow.global.security.jwt.JwtUtil;
@@ -31,6 +32,7 @@ public class AuthService {
     private final GuardianLinkRepository guardianLinkRepository;
     private final DrivingSessionRepository drivingSessionRepository;
     private final MemberDeviceSettingRepository memberDeviceSettingRepository;
+    private final PointHistoryRepository pointHistoryRepository;
     private final KakaoAuthService kakaoAuthService;
     private final GoogleAuthService googleAuthService;
     private final JwtUtil jwtUtil;
@@ -135,6 +137,7 @@ public class AuthService {
         guardianLinkRepository.deleteByGuardianIdOrSeniorId(memberId);
         drivingSessionRepository.deleteByDriver_Id(memberId);
         memberDeviceSettingRepository.deleteByMemberId(memberId);
+        pointHistoryRepository.deleteByMemberId(memberId);
         memberRepository.delete(member);
     }
 }

--- a/src/main/java/backend/knowhow/domain/mission/repository/MemberMissionRepository.java
+++ b/src/main/java/backend/knowhow/domain/mission/repository/MemberMissionRepository.java
@@ -22,4 +22,6 @@ public interface MemberMissionRepository extends JpaRepository<MemberMission, Lo
 
     @Query("select mm from MemberMission mm join fetch mm.mission where mm.member = :member")
     List<MemberMission> findAllByMemberWithMission(Member member);
+
+    void deleteByMemberId(Long memberId);
 }

--- a/src/main/java/backend/knowhow/domain/mission/repository/PointHistoryRepository.java
+++ b/src/main/java/backend/knowhow/domain/mission/repository/PointHistoryRepository.java
@@ -12,4 +12,6 @@ import java.time.LocalDateTime;
 public interface PointHistoryRepository extends JpaRepository<PointHistory, Long> {
     // 월 범위로 조회
     Page<PointHistory> findAllByMemberAndCreatedAtGreaterThanEqualAndCreatedAtLessThan(Member member, LocalDateTime start, LocalDateTime end, Pageable pageable);
+
+    void deleteByMemberId(Long memberId);
 }


### PR DESCRIPTION
## 🚘 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요. 
- [x] 회원탈퇴 시 member_mission 내역 함께 삭제

## #️⃣ 테스트 내용
> 어떤 테스트를 수행했는지 명시해주세요.  
- [x] Postman 테스트
- [ ] 단위 테스트 수행
- [ ] 통합 테스트 수행

## 🔗 관련 이슈
- closes #52
---


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 회원 탈퇴 시 포인트 이력과 함께 관련된 미션 데이터도 함께 삭제되도록 개선했습니다. 이제 탈퇴 프로세스가 더욱 안정적으로 진행됩니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->